### PR TITLE
Making slug primary way for urls - and slugified title secondary

### DIFF
--- a/posts/posts.json
+++ b/posts/posts.json
@@ -1,5 +1,5 @@
 {
   "layout": "layouts/post.njk",
-  "permalink": "posts/{{ title | slug }}/index.html",
+  "permalink": "posts/{{ slug | title }}/index.html",
   "tags": "post"
 }


### PR DESCRIPTION
Simple logic: If the title is primary you will never be able to overwrite it, with the slug first you can overwrite it while leaving the title as wished.