### PR TITLE
Move the identity script into head of admin.html

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Netlify CMS</title>
+    <!-- Include Netlify Identity for authentication -->
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
-    <!-- Include Netlify Identity for authentication -->
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
     <script type="module" src="/admin/preview-templates/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Previously, when the identity script was  in the body tag there was an issue trying to access the admin panel. You would see a modal background (but no modal) and then not be able to access the admin panel (screen shot below).

Moving the identity script to the head tag in admin.html [as recommended by netlify docs](https://www.netlifycms.org/docs/add-to-your-site/#add-the-netlify-identity-widget) seemed to resolve the issue. 

I notice, however, I no longer get the nifty "you are logged in as [X]" modal

![image](https://user-images.githubusercontent.com/6607541/77133495-9e50d880-6a39-11ea-9860-5b27a90c76a6.png)
