### PR TITLE
Add custom thanks page after form submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Based on the [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog) re
 * Uses the official [Eleventy Navigation](https://www.11ty.dev/docs/plugins/navigation/) plugin to build menus
 * Sample pages and a blog with tag support
 * Netlify CMS with editor previews (thanks [@biilmann](https://github.com/biilmann)!)
-* Includes a working contact form
+* Includes a working contact form with a custom thanks page
 * CSS 2kb minified, inlined for fastest page render
 * Optional pipeline for minified inline JS
 * Pre-builds and minifies your HTML too

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Based on the [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog) re
 * Uses the official [Eleventy Navigation](https://www.11ty.dev/docs/plugins/navigation/) plugin to build menus
 * Sample pages and a blog with tag support
 * Netlify CMS with editor previews (thanks [@biilmann](https://github.com/biilmann)!)
-* Includes a working contact form with a custom thanks page
+* Includes a working contact form with a custom thanks page (thanks [@aalaap](https://github.com/aalaap)!)
 * CSS 2kb minified, inlined for fastest page render
 * Optional pipeline for minified inline JS
 * Pre-builds and minifies your HTML too

--- a/_includes/components/form.njk
+++ b/_includes/components/form.njk
@@ -1,4 +1,4 @@
-<form name="contact" method="POST" netlify>
+<form name="contact" method="POST" action="/contact/thanks.html" netlify>
   <label for="name">Name</label>
   <input type="text" name="name" id="name" autocomplete="name" placeholder="Your name" title="Please enter your name" required>
   <label for="email">Email</label>

--- a/pages/contact/thanks.md
+++ b/pages/contact/thanks.md
@@ -1,0 +1,11 @@
+---
+title: Thanks
+date: 2020-09-26T00:00:00.000Z
+permalink: /contact/thanks.html
+---
+
+Thank you for getting in touch!
+
+You can find the form submissions in your the <strong>Forms</strong> section under the Netlify site you deploy this to.
+
+<em>Note: If you're running this locally and you get a `Cannot POST /contact/thanks.html` error, it's because this only works when the site is deployed to Netlify.</em>


### PR DESCRIPTION
This PR adds a custom thank you page that is displayed after the contact form is submitted.

This redirect is a feature provided by Netlify Forms and as such it only works when deployed. 

This closes #42. 