### PR TITLE
Add serve command to readme and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Or build automatically when a template changes:
 npx @11ty/eleventy --watch
 ```
 
+Or build and host locally for local development:
+```
+npx @11ty/eleventy --serve
+```
+
 Or in debug mode:
 ```
 DEBUG=* npx @11ty/eleventy

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "npx eleventy",
     "watch": "npx eleventy --watch",
+    "serve": "npx eleventy --serve",
     "debug": "DEBUG=* npx eleventy"
   },
   "repository": {


### PR DESCRIPTION
As someone new to Eleventy as a whole, not having the `npx eleventy --serve` command mentioned in the readme was a bit confusing and it wasn't until I looked at the official  **11ty/eleventy-base-blog** and saw [this pr](https://github.com/11ty/eleventy-base-blog/pull/26/files) that I discovered how to run everything locally.

I think the same addition would be useful in this repo to clear things up for new users.